### PR TITLE
chore: move tabpanels out

### DIFF
--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -27,7 +27,7 @@ import image2 from './_story-assets/3x2.jpg';
 
 import { Bee, AiGenerate, CloudFoundry_1, Activity } from '@carbon/icons-react';
 import mdx from './PageHeader.mdx';
-import { TabList, Tab, TabPanels, TabPanel } from '../Tabs/Tabs';
+import { TabList, Tab, Tabs, TabPanels, TabPanel } from '../Tabs/Tabs';
 
 const tags = [
   {
@@ -143,50 +143,53 @@ const breadcrumbContentActions = (
 );
 
 export const Default = (args) => (
-  <PageHeader.Root>
-    <PageHeader.BreadcrumbBar
-      border={args.border}
-      pageActionsFlush={args.pageActionsFlush}
-      contentActionsFlush={args.contentActionsFlush}
-      renderIcon={args.renderBreadcrumbIcon ? BreadcrumbBeeIcon : null}
-      contentActions={breadcrumbContentActions}
-      pageActions={breadcrumbPageActions}>
-      <Breadcrumb>
-        <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
-        <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
-      </Breadcrumb>
-    </PageHeader.BreadcrumbBar>
-    <PageHeader.Content title={args.title}>
-      <PageHeader.ContentText subtitle="Subtitle">
-        Neque massa fames auctor maecenas leo. Mollis vehicula per, est justo.
-        Massa elementum class enim malesuada lacinia hendrerit enim erat
-        pellentesque. Sapien arcu lobortis est erat arcu nibh vehicula congue.
-        Nisi molestie primis lorem nascetur sem metus mattis etiam scelerisque.
-      </PageHeader.ContentText>
-    </PageHeader.Content>
-    <PageHeader.TabBar tags={tags}>
-      <PageHeader.Tabs>
-        <TabList>
-          <Tab>Tab 1</Tab>
-          <Tab>Tab 2</Tab>
-          <Tab>Tab 3</Tab>
-          <Tab>Tab 4</Tab>
-          <Tab>Tab 5</Tab>
-          <Tab>Tab 6</Tab>
-          <Tab>Tab 7</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>Tab Panel 1</TabPanel>
-          <TabPanel>Tab Panel 2</TabPanel>
-          <TabPanel>Tab Panel 3</TabPanel>
-          <TabPanel>Tab Panel 4</TabPanel>
-          <TabPanel>Tab Panel 5</TabPanel>
-          <TabPanel>Tab Panel 6</TabPanel>
-          <TabPanel>Tab Panel 7</TabPanel>
-        </TabPanels>
-      </PageHeader.Tabs>
-    </PageHeader.TabBar>
-  </PageHeader.Root>
+  <Tabs>
+    <PageHeader.Root>
+      <PageHeader.BreadcrumbBar
+        border={args.border}
+        pageActionsFlush={args.pageActionsFlush}
+        contentActionsFlush={args.contentActionsFlush}
+        renderIcon={args.renderBreadcrumbIcon ? BreadcrumbBeeIcon : null}
+        contentActions={breadcrumbContentActions}
+        pageActions={breadcrumbPageActions}>
+        <Breadcrumb>
+          <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+          <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+        </Breadcrumb>
+      </PageHeader.BreadcrumbBar>
+      <PageHeader.Content title={args.title}>
+        <PageHeader.ContentText subtitle="Subtitle">
+          Neque massa fames auctor maecenas leo. Mollis vehicula per, est justo.
+          Massa elementum class enim malesuada lacinia hendrerit enim erat
+          pellentesque. Sapien arcu lobortis est erat arcu nibh vehicula congue.
+          Nisi molestie primis lorem nascetur sem metus mattis etiam
+          scelerisque.
+        </PageHeader.ContentText>
+      </PageHeader.Content>
+      <PageHeader.TabBar tags={tags}>
+        <PageHeader.Tabs>
+          <TabList>
+            <Tab>Tab 1</Tab>
+            <Tab>Tab 2</Tab>
+            <Tab>Tab 3</Tab>
+            <Tab>Tab 4</Tab>
+            <Tab>Tab 5</Tab>
+            <Tab>Tab 6</Tab>
+            <Tab>Tab 7</Tab>
+          </TabList>
+        </PageHeader.Tabs>
+      </PageHeader.TabBar>
+    </PageHeader.Root>
+    <TabPanels>
+      <TabPanel>Tab Panel 1</TabPanel>
+      <TabPanel>Tab Panel 2</TabPanel>
+      <TabPanel>Tab Panel 3</TabPanel>
+      <TabPanel>Tab Panel 4</TabPanel>
+      <TabPanel>Tab Panel 5</TabPanel>
+      <TabPanel>Tab Panel 6</TabPanel>
+      <TabPanel>Tab Panel 7</TabPanel>
+    </TabPanels>
+  </Tabs>
 );
 
 Default.args = {
@@ -451,8 +454,39 @@ export const ContentWithContextualActionsAndPageActions = (args) => (
 
 export const TabBar = (args) => {
   return (
-    <PageHeader.Root>
-      <PageHeader.TabBar {...args}>
+    <Tabs>
+      <PageHeader.Root>
+        <PageHeader.TabBar {...args}>
+          <PageHeader.Tabs>
+            <TabList>
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+              <Tab>Tab 3</Tab>
+              <Tab>Tab 4</Tab>
+              <Tab>Tab 5</Tab>
+              <Tab>Tab 6</Tab>
+              <Tab>Tab 7</Tab>
+            </TabList>
+          </PageHeader.Tabs>
+        </PageHeader.TabBar>
+      </PageHeader.Root>
+      <TabPanels>
+        <TabPanel>Tab Panel 1</TabPanel>
+        <TabPanel>Tab Panel 2</TabPanel>
+        <TabPanel>Tab Panel 3</TabPanel>
+        <TabPanel>Tab Panel 4</TabPanel>
+        <TabPanel>Tab Panel 5</TabPanel>
+        <TabPanel>Tab Panel 6</TabPanel>
+        <TabPanel>Tab Panel 7</TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+};
+
+export const TabBarWithTabsAndTags = (args) => (
+  <Tabs>
+    <PageHeader.Root {...args}>
+      <PageHeader.TabBar tags={tags}>
         <PageHeader.Tabs>
           <TabList>
             <Tab>Tab 1</Tab>
@@ -463,46 +497,19 @@ export const TabBar = (args) => {
             <Tab>Tab 6</Tab>
             <Tab>Tab 7</Tab>
           </TabList>
-          <TabPanels>
-            <TabPanel>Tab Panel 1</TabPanel>
-            <TabPanel>Tab Panel 2</TabPanel>
-            <TabPanel>Tab Panel 3</TabPanel>
-            <TabPanel>Tab Panel 4</TabPanel>
-            <TabPanel>Tab Panel 5</TabPanel>
-            <TabPanel>Tab Panel 6</TabPanel>
-            <TabPanel>Tab Panel 7</TabPanel>
-          </TabPanels>
         </PageHeader.Tabs>
       </PageHeader.TabBar>
     </PageHeader.Root>
-  );
-};
-
-export const TabBarWithTabsAndTags = (args) => (
-  <PageHeader.Root {...args}>
-    <PageHeader.TabBar tags={tags}>
-      <PageHeader.Tabs>
-        <TabList>
-          <Tab>Tab 1</Tab>
-          <Tab>Tab 2</Tab>
-          <Tab>Tab 3</Tab>
-          <Tab>Tab 4</Tab>
-          <Tab>Tab 5</Tab>
-          <Tab>Tab 6</Tab>
-          <Tab>Tab 7</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>Tab Panel 1</TabPanel>
-          <TabPanel>Tab Panel 2</TabPanel>
-          <TabPanel>Tab Panel 3</TabPanel>
-          <TabPanel>Tab Panel 4</TabPanel>
-          <TabPanel>Tab Panel 5</TabPanel>
-          <TabPanel>Tab Panel 6</TabPanel>
-          <TabPanel>Tab Panel 7</TabPanel>
-        </TabPanels>
-      </PageHeader.Tabs>
-    </PageHeader.TabBar>
-  </PageHeader.Root>
+    <TabPanels>
+      <TabPanel>Tab Panel 1</TabPanel>
+      <TabPanel>Tab Panel 2</TabPanel>
+      <TabPanel>Tab Panel 3</TabPanel>
+      <TabPanel>Tab Panel 4</TabPanel>
+      <TabPanel>Tab Panel 5</TabPanel>
+      <TabPanel>Tab Panel 6</TabPanel>
+      <TabPanel>Tab Panel 7</TabPanel>
+    </TabPanels>
+  </Tabs>
 );
 
 export const DirectExports = (args) => (

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -26,7 +26,6 @@ import { MenuItem } from '../Menu';
 import { DefinitionTooltip } from '../Tooltip';
 import { AspectRatio } from '../AspectRatio';
 import { createOverflowHandler } from '@carbon/utilities';
-import { Tabs as BaseTabs } from '../Tabs/Tabs';
 import { OperationalTag, Tag } from '../Tag';
 import { TYPES } from '../Tag/Tag';
 import useOverflowItems from '../../internal/useOverflowItems';
@@ -749,7 +748,6 @@ const PageHeaderTabBar = React.forwardRef<
   // If no tabs but we have tags, render tags with other children
   return (
     <div className={classNames} ref={ref} {...other}>
-
       <Grid>
         <Column lg={16} md={8} sm={4}>
           {children}
@@ -757,12 +755,11 @@ const PageHeaderTabBar = React.forwardRef<
         </Column>
       </Grid>
       {children}
-
     </div>
   );
 });
 PageHeaderTabBar.displayName = 'PageHeaderTabBar';
-interface PageHeaderTabsProps extends React.ComponentProps<typeof BaseTabs> {
+interface PageHeaderTabsProps {
   children?: React.ReactNode;
   className?: string;
 }
@@ -774,36 +771,14 @@ const PageHeaderTabs = React.forwardRef<HTMLDivElement, PageHeaderTabsProps>(
   ) {
     const prefix = usePrefix();
 
-    const childrenArray = React.Children.toArray(children);
-    let tabListElement: React.ReactNode = null;
-    const otherChildren: React.ReactNode[] = [];
-
-    // extract the TabList component so we can wrap a needed div around for
-    // layout purposes
-    childrenArray.forEach((child: any) => {
-      if (
-        child?.type?.displayName === 'TabList' ||
-        child?.type?.name === 'TabList'
-      ) {
-        tabListElement = child;
-      } else {
-        otherChildren.push(child);
-      }
-    });
-
     return (
-      <BaseTabs {...other}>
-        {tabListElement && (
-          <div className={`${prefix}--page-header__tablist-wrapper`}>
-            <Grid>
-              <Column lg={16} md={8} sm={4}>
-                {tabListElement}
-              </Column>
-            </Grid>
-          </div>
-        )}
-        {otherChildren}
-      </BaseTabs>
+      <div {...other}>
+        <Grid>
+          <Column lg={16} md={8} sm={4}>
+            {children}
+          </Column>
+        </Grid>
+      </div>
     );
   }
 );

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -19,6 +19,7 @@
 @mixin page-header {
   .#{$prefix}--page-header {
     background-color: $layer-01;
+    border-block-end: 1px solid $border-subtle-01;
   }
 
   .#{$prefix}--page-header__breadcrumb-bar {
@@ -177,6 +178,10 @@
     block-size: 100%;
   }
 
+  .#{$prefix}--page-header__tab-bar {
+    margin-inline-start: -$spacing-05;
+  }
+
   .#{$prefix}--page-header__tab-bar--tablist {
     display: grid;
     grid-gap: $spacing-10;
@@ -197,17 +202,5 @@
 
   .#{$prefix}--page-header__tag-item {
     flex-shrink: 0;
-
-    .#{$prefix}--page-header__tablist-wrapper {
-      border-block-end: 1px solid $border-subtle-01;
-    }
-
-    .#{$prefix}--page-header__tab-bar .#{$prefix}--tabs {
-      margin-inline-start: -$spacing-05;
-    }
-
-    .#{$prefix}--tab-content {
-      background: $background;
-    }
   }
 }


### PR DESCRIPTION
Move `TabPanels` outside of `PageHeader` as it is considered page content and should be external to the `PageHeader`. This also simplifies the overflow tag logic that happens in the TabBar.

**Question:**
Do we need the `PageHeaderTabs` component anymore? It was used to set the Tabs Context before but now that we are manually wrapping the stories in `Tabs` it may no longer be needed. It serves no styling purpose either with these new changes.

### Changelog

**Changed**

- wrap the entire `PageHeader` and now external `TabPanels` component in `Tabs` in all stories that use Tabs
- adjust styling with this new structure

**Removed**

- remove logic in `PageHeaderTabs` that separates the `TabList` from `TabPanels` in the children
- remove extending `Tabs` from the `PageHeaderTabs` component

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
